### PR TITLE
docs: correct typos in README overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Here, I am using linear equations to make a shield around the robot for obstacle
 
 I am considering +ve slope slope line and -ve slope line for making it as a triangle.
 
-Overview: A subscriber function receives laser scan data (Format: 1-D array of float values) from hokuyu sensor and checking whether data range values fall whithin robot shield. If obstacle detected whithin the limit, then the robot will immediately stop by publishing 0 value on cmd_vel topic (subscribed by gazebo). If no obstacle detects,then robot will constinue its jounrney forward untill it hits the obstacle.
+Overview: A subscriber function receives laser scan data (Format: 1-D array of float values) from hokuyu sensor and checking whether data range values fall whithin robot shield. If obstacle detected whithin the limit, then the robot will immediately stop by publishing 0 value on cmd_vel topic (subscribed by gazebo). If no obstacle detects,then robot will continue its journey forward until it hits the obstacle.
 
 ## Logic:
 Here, I am using linear equations to make a shield around the robot for obstacle detection.


### PR DESCRIPTION
## Summary
- fix misspellings in README overview

## Testing
- `pre-commit run --files README.md` *(fails: command not found)*
- `catkin_make` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ddfd37aa48321beb5bc8a297305d3