### PR TITLE
Fix front obstacle index bounds check

### DIFF
--- a/src/my_robot/src/safety_detector_node.cpp
+++ b/src/my_robot/src/safety_detector_node.cpp
@@ -73,7 +73,8 @@ void Safety_check(const sensor_msgs::LaserScan::ConstPtr& msg)
 
 
         //front side obstacle
-        if (msg->ranges[half_len-1] < height){
+        if (half_len < msg->ranges.size() && msg->ranges[half_len] < height)
+        {
             is_obstacle = true;
             ROS_INFO("OBSTACLE ON FRONT SIDE");
             break;


### PR DESCRIPTION
## Summary
- prevent out-of-bounds access in front obstacle check by ensuring the half-length index is valid

## Testing
- `catkin_make` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689de16bfd0c83219ee85dfd77a989bd