### PR TITLE
Add unit tests for safety detector node

### DIFF
--- a/src/my_robot/CMakeLists.txt
+++ b/src/my_robot/CMakeLists.txt
@@ -210,3 +210,8 @@ include_directories(include ${catkin_INCLUDE_DIRS})
 add_executable(safety_detector_node src/safety_detector_node.cpp)
 target_link_libraries(safety_detector_node ${catkin_LIBRARIES})
 
+catkin_add_gtest(safety_detector_node_test test/safety_detector_node_test.cpp)
+if(TARGET safety_detector_node_test)
+  target_link_libraries(safety_detector_node_test ${catkin_LIBRARIES})
+endif()
+

--- a/src/my_robot/test/safety_detector_node_test.cpp
+++ b/src/my_robot/test/safety_detector_node_test.cpp
@@ -1,0 +1,46 @@
+#include <geometry_msgs/Twist.h>
+#include <gtest/gtest.h>
+#include <ros/ros.h>
+
+// Rename main to avoid duplicate symbol when including node source
+#define main dont_use_main
+#include "../src/safety_detector_node.cpp"
+#undef main
+
+geometry_msgs::Twist last_cmd;
+void cmdVelCallback(const geometry_msgs::Twist::ConstPtr &msg) {
+  last_cmd = *msg;
+}
+
+class MoveCommandTest : public ::testing::Test {
+protected:
+  ros::NodeHandle nh;
+  ros::Subscriber sub;
+
+  void SetUp() override {
+    last_cmd = geometry_msgs::Twist();
+    drive_pub = nh.advertise<geometry_msgs::Twist>("cmd_vel", 1, true);
+    sub = nh.subscribe("cmd_vel", 1, cmdVelCallback);
+    while (drive_pub.getNumSubscribers() == 0 || sub.getNumPublishers() == 0) {
+      ros::Duration(0.01).sleep();
+    }
+  }
+};
+
+TEST_F(MoveCommandTest, PublishesForwardWhenNoObstacle) {
+  Move(false);
+  ros::spinOnce();
+  EXPECT_DOUBLE_EQ(0.2, last_cmd.linear.x);
+}
+
+TEST_F(MoveCommandTest, PublishesStopWhenObstacle) {
+  Move(true);
+  ros::spinOnce();
+  EXPECT_DOUBLE_EQ(0.0, last_cmd.linear.x);
+}
+
+int main(int argc, char **argv) {
+  ros::init(argc, argv, "safety_detector_node_test");
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## Summary
- add gtests to verify Move publishes expected Twist commands
- enable gtest build in CMakeLists.txt

## Testing
- `catkin_make run_tests` *(fails: command not found: catkin_make)*

------
https://chatgpt.com/codex/tasks/task_e_689de16e90d883219d4615b34e96804c